### PR TITLE
Added encoding conversion to "from" header as well

### DIFF
--- a/src/InvoicePrinter.php
+++ b/src/InvoicePrinter.php
@@ -507,7 +507,7 @@ class InvoicePrinter extends FPDF
                 $this->Ln(5);
                 $this->SetTextColor(50, 50, 50);
                 $this->SetFont($this->font, 'B', 10);
-                $this->Cell($width, $lineheight, $this->from[0] ?? 0, 0, 0, 'L');
+                $this->Cell($width, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $this->from[0] ?? 0), 0, 0, 'L');
                 $this->Cell(0, $lineheight, iconv(self::ICONV_CHARSET_INPUT, self::ICONV_CHARSET_OUTPUT_A, $this->to[0] ?? 0), 0, 0, 'L');
                 $this->SetFont($this->font, '', 8);
                 $this->SetTextColor(100, 100, 100);


### PR DESCRIPTION
The first (bold) "from" row was missing character encoding conversion, so it had issues displaying special characters (`Ä` and `Ü` for my case). I added the same encoding conversion with `iconv` function to the first "from" row, as the first row of "to" already had it.
